### PR TITLE
Update to golang 1.22 & dependencies (deep, uuid)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.17'
+        go-version: '1.22'
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run Linters
       uses: golangci/golangci-lint-action@v3
       with:
@@ -25,16 +25,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.15', '1.16', '1.17']
+        go-version: ['1.22']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
       if: success()
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Run Tests
       run: go test -v -covermode=count

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: Run Linters
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.43
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run Linters
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.43
+        version: v1.59
 
   test:
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/heimdalr/dag
 
-go 1.20
+go 1.22
 
 // require github.com/hashicorp/terraform v0.12.20
 
 require (
 	github.com/emirpasic/gods v1.18.1
-	github.com/go-test/deep v1.0.7
-	github.com/google/uuid v1.1.2
+	github.com/go-test/deep v1.1.1
+	github.com/google/uuid v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,9 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
$ go get -u github.com/go-test/deep
go: upgraded github.com/go-test/deep v1.0.7 => v1.1.1

$ go get -u github.com/google/uuid
go: upgraded github.com/google/uuid v1.1.2 => v1.6.0

Updated actions to latest versions
Updated golint version to 1.59 (latest).
- Earlier one does not handle golang 1.22 ok, it fails.
